### PR TITLE
FCBHDBP-612 update storeDay to consider order_column if add_to_end is passed

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -514,6 +514,7 @@ class PlansController extends APIController
      *     security={{"api_token":{}}},
      *     @OA\Parameter(name="plan_id", in="path", required=true, @OA\Schema(ref="#/components/schemas/Plan/properties/id")),
      *     @OA\Parameter(name="days", in="query", required=true, @OA\Schema(type="integer"), description="Number of days to add to the plan"),
+     *     @OA\Parameter(name="add_to_end", in="query", required=false, @OA\Schema(type="true"), description="If new days to add should be added to end of list of days")
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
@@ -566,10 +567,14 @@ class PlansController extends APIController
             ->where('plan_id', $plan->id)
             ->where('user_id', $user->id)
             ->get()->pluck('id');
-        $plan_days_data = $new_playlists->map(function ($item) use ($plan) {
+
+        $add_to_end = checkParam('add_to_end') ?? false;
+
+        $plan_days_data = $new_playlists->map(function ($item, $index) use ($plan, $add_to_end, $current_days_size) {
             return [
                 'plan_id'               => $plan->id,
                 'playlist_id'           => $item,
+                'order_column' => $add_to_end ? $current_days_size + ($index + 1) : 0,
             ];
         })->toArray();
         Playlist::whereIn('id', $new_playlists)->update(['name' => '', 'updated_at' => 'created_at']);


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
<!--- Describe your changes in detail -->
Currently there is no specific ordering when adding a new day to a plan and what is happening in [Bible.is](http://bible.is/) is if the user reorder the current list of days in a plan and then add a new day, the new day is not being added at the end as it should (Bible.is ticket [FCBH-6440](https://fullstacklabs.atlassian.net/browse/FCBH-6440) 

Update the `POST /plans/{plan_id}/day` endpoint to receive a parameter `add_to_end` and if `add_to_end` is `true` we should consider the current amount of days in the plan and then add `order_column` according to that

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBHDBP-01](https://fullstacklabs.atlassian.net/browse/FCBHDBP-612) -->
[FCBHDBP-612](https://fullstacklabs.atlassian.net/browse/FCBHDBP-612)

## How Do I QA This
<!--- Explain how a developer would qa out these changes locally -->

Create a plan with more than one day so you can reorder later. Here you can also see that in the Scripts I'm getting the newly created plan and saving `plan_id_delete_day` and `reordered_days`, so I can use in the next call
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-c6632f47-ccde-43db-b65c-1a693ac2e0b2?action=share&source=copy-link&creator=18435954&ctx=documentation

Now update the plan and reorder the days 
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-1010dc41-7ec3-49da-8d75-11ec340aff10?action=share&source=copy-link&creator=18435954&ctx=documentation

Now add a new day by passing add_to_end as true
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-cb4feb4d-b038-458d-bb6b-dbea14c8f83d?action=share&source=copy-link&creator=18435954&ctx=documentation

Now get the same plan again and notice that it's in the as it should
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-dcd2cbb2-ea68-4b22-976d-6e20ff4f1539?action=share&source=copy-link&creator=18435954&ctx=documentation

If you do the same steps above and pass add_to_end as false (or if you don't pass it), you will see that the order is wrong and the test from the previous call to get the plan fails

## Screenshots (if appropriate)
<!--- Add screenshots or delete this section -->


[FCBH-6440]: https://fullstacklabs.atlassian.net/browse/FCBH-6440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FCBHDBP-612]: https://fullstacklabs.atlassian.net/browse/FCBHDBP-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ